### PR TITLE
I will include overall market sentiment in the LLM prompt.

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -212,7 +212,7 @@ with st.sidebar:
             try:
                 # 1. Get the latest company context data
                 logger.info("Streamlit App: Calling prepare_llm_context_data()")
-                top_companies_df = prepare_llm_context_data()
+                top_companies_df, market_sentiment_str = prepare_llm_context_data() # Unpack two values
 
                 if top_companies_df.empty:
                     logger.warning("Streamlit App: No company context data returned from prepare_llm_context_data().")
@@ -220,7 +220,7 @@ with st.sidebar:
 
                 # 2. Generate the dynamic prompt
                 logger.info(f"Streamlit App: Generating dynamic prompt for user query: {prompt}")
-                dynamic_prompt_text = generate_dynamic_prompt(prompt, top_companies_df)
+                dynamic_prompt_text = generate_dynamic_prompt(prompt, top_companies_df, market_sentiment_str) # Pass market_sentiment_str
                 logger.debug(f"Streamlit App: Generated prompt: {dynamic_prompt_text}")
 
                 # 3. Get response from OpenAI


### PR DESCRIPTION
I modified `scripts/stock_predictor.py`:
- I added `get_qualitative_market_sentiment()` to examine `predict_growth.csv` and determine a qualitative overall market sentiment string.
- `prepare_llm_context_data()` now calls this function and returns both the top companies DataFrame and the market sentiment string.
- `generate_dynamic_prompt()` now accepts the market sentiment string and includes it in the prompt provided to the LLM.

I updated `streamlit_app.py`:
- I modified calls to `prepare_llm_context_data` and `generate_dynamic_prompt` to handle the new return value and argument (overall market sentiment string).