### PR TITLE
Fix: Correct VIX fetching and normalize company names in sentiment su…

### DIFF
--- a/scripts/generate_company_sentiment.py
+++ b/scripts/generate_company_sentiment.py
@@ -1,27 +1,94 @@
 import pandas as pd
+import os
+import sys
+import logging
 
-# Load file with company column
-df = pd.read_csv("data/merged_sentiment_output_with_companies_and_sentiment.csv")
+# Add parent directory to sys.path to allow imports from 'utils'
+current_script_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_script_dir)
+sys.path.append(parent_dir)
 
-print("Columns in file:", df.columns.tolist())
-print(df.head())
+from utils.normalization_utils import normalize_company_name, _load_normalization_data
 
-# Filter only rows with company
-df = df[df["company"].notnull() & (df["company"] != "")]
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-# Count sentiment categories per company
-summary = df.groupby("company")["sentiment"].value_counts().unstack(fill_value=0).reset_index()
+# Define input and output file paths using os.path.join for compatibility
+input_file = os.path.join(parent_dir, "data", "merged_sentiment_output_with_companies_and_sentiment.csv")
+output_file = os.path.join(parent_dir, "data", "company_sentiment_normalized.csv")
 
-# Rename columns for clarity
-summary.columns.name = None
-summary = summary.rename(columns={"positive": "positive", "neutral": "neutral", "negative": "negative"})
-summary = summary.fillna(0)
+try:
+    # Load file with company column
+    df = pd.read_csv(input_file)
+    logger.info(f"Successfully loaded input file: {input_file}")
+    logger.info(f"Columns in file: {df.columns.tolist()}")
+    logger.info(f"Sample of data:\n{df.head()}")
 
-# Ensure all sentiment columns exist
-for col in ["positive", "neutral", "negative"]:
-    if col not in summary.columns:
-        summary[col] = 0
+    # Ensure normalization data is loaded
+    _load_normalization_data()
+    logger.info("Normalization data loaded from utils.")
 
-# Save the sentiment summary
-summary.to_csv("data/company_sentiment_normalized.csv", index=False)
-print("✅ Saved sentiment summary to → data/company_sentiment_normalized.csv")
+    # Handle cases where 'company' column might be missing or all NaN
+    if 'company' not in df.columns:
+        logger.error("'company' column not found in input CSV. Cannot proceed.")
+        sys.exit(1)
+
+    # Normalize the 'company' column
+    # Convert to string first to handle potential float NaNs or other types
+    df['normalized_company'] = df['company'].astype(str).apply(normalize_company_name)
+    logger.info("Applied company name normalization.")
+    logger.info(f"Sample of normalized names:\n{df[['company', 'normalized_company']].head(10)}")
+
+
+    # Filter only rows with successfully normalized company names
+    original_row_count = len(df)
+    df = df[df["normalized_company"].notnull() & (df["normalized_company"] != "")]
+    logger.info(f"Filtered out {original_row_count - len(df)} rows with no valid normalized company name.")
+
+    if df.empty:
+        logger.warning("DataFrame is empty after filtering for normalized company names. No sentiment summary will be generated.")
+        # Create an empty summary df with expected columns to prevent downstream errors if the file is expected
+        summary = pd.DataFrame(columns=['company', 'negative', 'neutral', 'positive'])
+    elif 'sentiment' not in df.columns:
+        logger.error("'sentiment' column not found in input CSV after filtering. Cannot generate sentiment summary.")
+        summary = pd.DataFrame(columns=['company', 'negative', 'neutral', 'positive']) # Output empty structure
+    else:
+        # Count sentiment categories per normalized company
+        logger.info("Aggregating sentiment counts per normalized company...")
+        summary = df.groupby("normalized_company")["sentiment"].value_counts().unstack(fill_value=0).reset_index()
+
+        # Rename columns for clarity
+        summary.columns.name = None
+        # Ensure standard column names, even if some sentiments don't appear for any company
+        for sentiment_type in ["positive", "neutral", "negative"]:
+            if sentiment_type not in summary.columns:
+                summary[sentiment_type] = 0
+
+        # Rename the 'normalized_company' column to 'company' for the output file
+        summary = summary.rename(columns={"normalized_company": "company",
+                                          "positive": "positive",
+                                          "neutral": "neutral",
+                                          "negative": "negative"})
+        summary = summary.fillna(0) # Fill any remaining NaNs just in case
+
+    # Ensure all required sentiment columns exist in the final summary, even if empty
+    for col in ["positive", "neutral", "negative"]:
+        if col not in summary.columns:
+            summary[col] = 0
+
+    # Select and order columns for the output CSV
+    final_columns = ['company', 'negative', 'neutral', 'positive']
+    summary = summary[final_columns]
+
+
+    # Save the sentiment summary
+    summary.to_csv(output_file, index=False)
+    logger.info(f"✅ Saved sentiment summary to → {output_file}")
+    logger.info(f"Final summary sample:\n{summary.head()}")
+
+except FileNotFoundError:
+    logger.error(f"Error: Input file not found at {input_file}. Please ensure prerequisite scripts have run.")
+except Exception as e:
+    logger.error(f"An unexpected error occurred: {e}", exc_info=True)
+
+print("✅ generate_company_sentiment.py processing complete.") # Keep simple print for run_all.py

--- a/scripts/market_sentiment.py
+++ b/scripts/market_sentiment.py
@@ -21,10 +21,25 @@ class MarketSentiment:
         
         try:
             # Get VIX (Volatility Index)
-            vix = yf.download(self.vix_symbol, start=start_date, end=end_date)['Adj Close']
+            # Changed 'Adj Close' to 'Close' as it's more reliable for indices
+            vix_data = yf.download(self.vix_symbol, start=start_date, end=end_date)
+            if 'Close' not in vix_data.columns:
+                logger.error(f"Could not find 'Close' column in VIX data. Columns: {vix_data.columns}")
+                return None
+            vix = vix_data['Close']
+
             # Get S&P 500
-            sp500 = yf.download(self.sp500_symbol, start=start_date, end=end_date)['Adj Close']
+            # Changed 'Adj Close' to 'Close'
+            sp500_data = yf.download(self.sp500_symbol, start=start_date, end=end_date)
+            if 'Close' not in sp500_data.columns:
+                logger.error(f"Could not find 'Close' column in S&P 500 data. Columns: {sp500_data.columns}")
+                return None
+            sp500 = sp500_data['Close']
             
+            if vix.empty or sp500.empty:
+                logger.error("VIX or S&P 500 data is empty after download.")
+                return None
+
             # Calculate daily returns and moving averages
             sp500_returns = sp500.pct_change().dropna()
             vix_returns = vix.pct_change().dropna()

--- a/scripts/normalize_companies.py
+++ b/scripts/normalize_companies.py
@@ -1,8 +1,14 @@
 import pandas as pd
-from thefuzz import process
-import re
 import logging
 import os
+import sys
+
+# Add parent directory to sys.path to allow imports from 'utils'
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(parent_dir)
+
+from utils.normalization_utils import normalize_company_name, _load_normalization_data
 
 # Create logs directory if it doesn't exist
 os.makedirs('logs', exist_ok=True)
@@ -16,141 +22,31 @@ logging.basicConfig(
         logging.StreamHandler()
     ]
 )
+logger = logging.getLogger(__name__)
 
 # Input: raw NER output
-input_file = "data/merged_sentiment_output_with_companies.csv"
-nasdaq_file = "data/nasdaq_top_companies.csv"
-output_file = "data/merged_sentiment_output_with_companies_normalized.csv"
-mapping_file = "data/company_name_mapping.csv"
+input_file = os.path.join(parent_dir, "data", "merged_sentiment_output_with_companies.csv")
+# nasdaq_file no longer needed here directly, it's used by normalization_utils
+output_file = os.path.join(parent_dir, "data", "merged_sentiment_output_with_companies_normalized.csv")
+mapping_file = os.path.join(parent_dir, "data", "company_name_mapping.csv") # This is an output review file
 
 # Load files
 try:
     df = pd.read_csv(input_file)
-    nasdaq_df = pd.read_csv(nasdaq_file)
-    logging.info(f"Loaded input files. Found {len(df)} records and {len(nasdaq_df)} NASDAQ companies.")
+    logger.info(f"Loaded input file: {input_file}. Found {len(df)} records.")
+    # Ensure normalization data (like NASDAQ list) is loaded in the utility module
+    _load_normalization_data()
+except FileNotFoundError as e:
+    logger.error(f"Error: Input file not found: {e.filename}. Please check the path: {input_file}")
+    sys.exit(1) # Exit if critical input file is missing
 except Exception as e:
-    logging.error(f"Error loading input files: {str(e)}")
+    logger.error(f"Error loading input file or normalization data: {str(e)}")
     raise
 
-# Preprocess company names
-def clean_company_name(name):
-    if not isinstance(name, str) or not name.strip():
-        return ""
-    # Remove common suffixes, special chars, and extra spaces
-    name = re.sub(r'[^\w\s]', ' ', name.lower())
-    name = re.sub(r'\b(inc|llc|ltd|corp|corporation|company|co|plc|holdings|technologies|international|group)\b', '', name)
-    return ' '.join(name.split()).strip()
 
-# Create cleaned versions for matching
-nasdaq_df['clean_name'] = nasdaq_df['Company'].fillna('').apply(clean_company_name)
-name_mapping = dict(zip(nasdaq_df['clean_name'], nasdaq_df['Company']))
-clean_names = list(name_mapping.keys()) # list of cleaned official Nasdaq names
-
-# Create ticker_map
-ticker_map = {}
-for _, row in nasdaq_df.iterrows():
-    ticker = row['Ticker']
-    company_name = row['Company']
-    if pd.notna(ticker) and pd.notna(company_name):
-        ticker_map[ticker.upper()] = company_name
-logging.info(f"Created ticker_map with {len(ticker_map)} entries.")
-
-# Create common_name_map
-common_name_map = {
-    "google": "Alphabet Inc. (Class A)",  # Or Class C, decide on a standard, typically A for primary
-    "alphabet": "Alphabet Inc. (Class A)",
-    "apple": "Apple Inc.",
-    "microsoft": "Microsoft",
-    "amazon": "Amazon",
-    "nvidia": "Nvidia",
-    "meta": "Meta Platforms",
-    "tesla": "Tesla, Inc."
-    # Add more common names as needed, ensuring they map to the *exact* names from nasdaq_top_companies.csv
-}
-# Ensure common_name_map values are in official names, if not, find the closest official name
-for common, official_guess in common_name_map.items():
-    if official_guess not in name_mapping.values():
-        logging.warning(f"Common name '{common}' maps to '{official_guess}' which is not an official Nasdaq name. Attempting to find a match.")
-        # Attempt to find a match in official names
-        cleaned_guess = clean_company_name(official_guess)
-        if cleaned_guess in name_mapping:
-            common_name_map[common] = name_mapping[cleaned_guess]
-            logging.info(f"Updated common_name_map: '{common}' now maps to '{name_mapping[cleaned_guess]}'")
-        else:
-            # Fallback to fuzzy match for the guess against official names
-            match, score = process.extractOne(cleaned_guess, clean_names)
-            if score >= 90: # High threshold for this auto-correction
-                common_name_map[common] = name_mapping[match]
-                logging.info(f"Fuzzy matched common_name_map: '{common}' now maps to '{name_mapping[match]}' (score: {score})")
-            else:
-                logging.error(f"Could not confidently map common name '{common}' (guessed '{official_guess}') to an official Nasdaq name. Please check mapping.")
-
-
-logging.info(f"Created common_name_map with {len(common_name_map)} entries.")
-
-
-def normalize_name(name):
-    if not isinstance(name, str) or not name.strip():
-        return ""
-
-    # 1. Direct Ticker Match
-    # Attempt to extract potential tickers (e.g., all-caps words of 1-5 length)
-    potential_tickers = re.findall(r'\b([A-Z]{1,5})\b', name)
-    for ticker in potential_tickers:
-        if ticker in ticker_map:
-            official_name = ticker_map[ticker]
-            logging.info(f"Normalized '{name}' to '{official_name}' via direct ticker map ('{ticker}')")
-            return official_name
-
-    cleaned_name_lower = clean_company_name(name) # Also converts to lowercase
-    if not cleaned_name_lower:
-        logging.debug(f"Could not normalize '{name}' after cleaning, result is empty.")
-        return ""
-
-    # 2. Common Name Match
-    if cleaned_name_lower in common_name_map:
-        official_name = common_name_map[cleaned_name_lower]
-        logging.info(f"Normalized '{name}' (cleaned: '{cleaned_name_lower}') to '{official_name}' via common name map")
-        return official_name
-
-    # 3. Exact Cleaned Match (Existing Logic)
-    if cleaned_name_lower in name_mapping:
-        official_name = name_mapping[cleaned_name_lower]
-        logging.info(f"Normalized '{name}' (cleaned: '{cleaned_name_lower}') to '{official_name}' via exact cleaned match")
-        return official_name
-    
-    # 4. Fuzzy Match (Existing Logic as Fallback)
-    try:
-        # Ensure clean_names is not empty and cleaned_name_lower is not empty
-        if not clean_names:
-            logging.warning("clean_names list is empty, skipping fuzzy match.")
-            return ""
-        if not cleaned_name_lower: # Should be caught earlier, but as a safeguard
-            logging.warning(f"Cleaned name for '{name}' is empty, skipping fuzzy match.")
-            return ""
-
-        match_result = process.extractOne(cleaned_name_lower, clean_names)
-        if match_result:
-            match, score = match_result
-            # Consider adjusting the score threshold if necessary (e.g., to 70 or 75)
-            if score >= 70: # Adjusted score from 60 to 70 for potentially better accuracy
-                official_name = name_mapping[match]
-                logging.info(f"Normalized '{name}' (cleaned: '{cleaned_name_lower}') to '{official_name}' via fuzzy match (score: {score})")
-                return official_name
-            else:
-                logging.info(f"Fuzzy match score for '{name}' (cleaned: '{cleaned_name_lower}') was {score}, below threshold 70. No match.")
-        else:
-            logging.info(f"No fuzzy match found for '{name}' (cleaned: '{cleaned_name_lower}'). process.extractOne returned None.")
-
-    except Exception as e:
-        logging.warning(f"Error during fuzzy matching for '{name}' (cleaned: '{cleaned_name_lower}'): {str(e)}")
-    
-    logging.info(f"No normalization match found for: '{name}' (cleaned: '{cleaned_name_lower}')")
-    return ""
-
-# Apply normalization
-logging.info("Starting company name normalization...")
-df["normalized_company"] = df["company"].astype(str).apply(normalize_name)
+# Apply normalization using the imported function
+logger.info("Starting company name normalization using normalization_utils...")
+df["normalized_company"] = df["company"].astype(str).apply(normalize_company_name)
 
 # Save mapping for review
 mapping_df = df[["company", "normalized_company"]].drop_duplicates()

--- a/scripts/stock_predictor.py
+++ b/scripts/stock_predictor.py
@@ -5,15 +5,36 @@ from pathlib import Path
 import pandas as pd
 from dotenv import load_dotenv
 from openai import OpenAI
+import re # For parsing user query
+
+# Add parent directory to sys.path to allow imports from 'utils'
+current_script_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_script_dir)
+sys.path.append(parent_dir)
+
+from utils.normalization_utils import normalize_company_name, get_ticker_for_company, _load_normalization_data as load_norm_data
+from utils.yfinance_utils import get_current_stock_data
 
 # Load environment variables from .env file
-env_path = Path(__file__).parent / '.env'
-load_dotenv(dotenv_path=env_path)
+# Assuming .env is in the parent directory (project root) or this script's directory
+env_path_script_dir = Path(__file__).parent / '.env'
+env_path_parent_dir = Path(__file__).parent.parent / '.env'
+
+if os.path.exists(env_path_script_dir):
+    load_dotenv(dotenv_path=env_path_script_dir)
+    env_path = env_path_script_dir
+elif os.path.exists(env_path_parent_dir):
+    load_dotenv(dotenv_path=env_path_parent_dir)
+    env_path = env_path_parent_dir
+else:
+    env_path = None
+
 
 # Configure logging
+# Change level to DEBUG to see more detailed logs for diagnosing this issue
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    level=logging.DEBUG, # << TEMP CHANGE TO DEBUG
+    format="%(asctime)s - %(name)s - %(levelname)s - %(module)s:%(lineno)d - %(message)s",
     handlers=[logging.StreamHandler(sys.stdout)],
 )
 logger = logging.getLogger(__name__)
@@ -21,9 +42,13 @@ logger = logging.getLogger(__name__)
 # Ensure OPENAI_API_KEY is loaded from environment variables
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 if not OPENAI_API_KEY:
-    logger.warning("OPENAI_API_KEY environment variable not found in .env file or environment variables.")
+    logger.warning("OPENAI_API_KEY environment variable not found.")
+    if env_path:
+        logger.warning(f"Looked for .env file at: {env_path.absolute()} and {env_path_parent_dir.absolute()}")
+    else:
+        logger.warning(f"No .env file found at {env_path_script_dir.absolute()} or {env_path_parent_dir.absolute()}")
     logger.warning(f"Current working directory: {os.getcwd()}")
-    logger.warning(f"Looking for .env file at: {env_path.absolute()}")
+
 
 # Helper function for formatting values in the prompt
 def format_value_for_prompt(value):
@@ -36,83 +61,248 @@ def format_value_for_prompt(value):
             return str(value)
     return "N/A"
 
+def parse_user_query_for_companies(user_query):
+    normalized_full_query = normalize_company_name(user_query)
+    if normalized_full_query:
+        logger.debug(f"Normalized full user query '{user_query}' to '{normalized_full_query}'")
+        return [normalized_full_query]
+
+    potential_terms = re.split(r'[\s,]+(?:and|or)?[\s,]*', user_query, flags=re.IGNORECASE)
+    normalized_companies = set()
+    for term in potential_terms:
+        term = term.strip()
+        if not term or term.lower() in ["stock", "stocks", "company", "companies", "sector", "market", "tomorrow", "ktomorrow", "stco"]:
+            continue
+        normalized_name = normalize_company_name(term)
+        if normalized_name:
+            logger.debug(f"Normalized term '{term}' from user query to '{normalized_name}'")
+            normalized_companies.add(normalized_name)
+        else:
+            logger.debug(f"Term '{term}' from user query could not be normalized to a known company: '{term}'")
+    return list(normalized_companies)
+
+
 def prepare_llm_context_data(user_query, top_n=25):
-    """
-    Loads, processes, and filters data from various CSVs to prepare the context for the LLM.
-    This version is used by the Streamlit application. LSTM components have been removed.
-    Returns a tuple: (DataFrame of top N companies + queried companies, qualitative market sentiment string).
-    """
-    logger.info(f"Preparing LLM context for query (LSTM removed): '{user_query}' with top_n={top_n}")
-    current_dir = os.path.dirname(__file__)
+    logger.info(f"Starting LLM context preparation for query: '{user_query}'")
+
+    load_norm_data()
     
-    company_sentiment_path = os.path.join(current_dir, "..", "data", "company_sentiment_normalized.csv")
-    predict_growth_path = os.path.join(current_dir, "..", "data", "predict_growth.csv")
-    macro_sentiment_path = os.path.join(current_dir, "..", "data", "macro_sentiment.csv")
-    # nasdaq_companies_path = os.path.join(current_dir, "..", "data", "nasdaq_top_companies.csv") # Currently unused
+    queried_companies_normalized = parse_user_query_for_companies(user_query)
+    logger.info(f"Normalized companies from query '{user_query}': {queried_companies_normalized}")
+
+    data_dir = os.path.join(parent_dir, "data")
+    company_sentiment_path = os.path.join(data_dir, "company_sentiment_normalized.csv")
+    predict_growth_path = os.path.join(data_dir, "predict_growth.csv")
+    macro_sentiment_path = os.path.join(data_dir, "macro_sentiment.csv")
+
+    final_df = pd.DataFrame()
 
     try:
-        company_df = pd.read_csv(company_sentiment_path)
-        growth_df = pd.read_csv(predict_growth_path)
+        logger.debug(f"Loading company sentiment from: {company_sentiment_path}")
+        company_df_raw = pd.read_csv(company_sentiment_path)
+        logger.debug(f"Loaded company_df_raw. Shape: {company_df_raw.shape}. Columns: {company_df_raw.columns.tolist()}")
+        logger.debug(f"Sample company_df_raw 'company' before upper: \n{company_df_raw['company'].head().apply(type).value_counts()}\n{company_df_raw['company'].head()}")
+
+
+        logger.debug(f"Loading growth data from: {predict_growth_path}")
+        growth_df_raw = pd.read_csv(predict_growth_path)
+        logger.debug(f"Loaded growth_df_raw. Shape: {growth_df_raw.shape}. Columns: {growth_df_raw.columns.tolist()}")
+        logger.debug(f"Sample growth_df_raw 'company' before upper: \n{growth_df_raw['company'].head().apply(type).value_counts()}\n{growth_df_raw['company'].head()}")
+
+
+        logger.debug(f"Loading macro data from: {macro_sentiment_path}")
         macro_df = pd.read_csv(macro_sentiment_path)
-        # mapping_df = pd.read_csv(nasdaq_companies_path) # Not used in current merge
+        logger.debug(f"Loaded macro_df. Shape: {macro_df.shape}. Columns: {macro_df.columns.tolist()}")
 
-        # Normalize ticker columns for merging
-        company_df['company'] = company_df['company'].str.upper()
-        growth_df['company'] = growth_df['company'].str.upper()
+        # Store original company names from growth_df for accurate ticker lookup later
+        # as get_ticker_for_company expects original casing from nasdaq_top_companies.csv
+        growth_df = growth_df_raw.copy() # Work with a copy
+        growth_df['original_company_for_ticker_lookup'] = growth_df_raw['company']
+
+        # For merging, use uppercased company names
+        company_df = company_df_raw.copy()
+        company_df['company_upper_merge_key'] = company_df_raw['company'].astype(str).str.upper()
+        growth_df['company_upper_merge_key'] = growth_df_raw['company'].astype(str).str.upper()
         
-        # Merge company sentiment with growth data
-        # Assumed: growth_df has 'company', 'growth_score', 'current_price', 'market_sentiment', 'theme'
-        # Assumed: company_df has 'company', 'positive', 'neutral', 'negative'
-        merged_df = pd.merge(growth_df, company_df, on="company", how="left")
+        logger.debug(f"Unique company keys in company_df for merge (first 5): {company_df['company_upper_merge_key'].unique()[:5]}")
+        logger.debug(f"Unique company keys in growth_df for merge (first 5): {growth_df['company_upper_merge_key'].unique()[:5]}")
 
-        # LSTM loading and merging logic REMOVED
+        # Merge 1: growth_df with company_df (sentiment)
+        logger.info("Merging growth data with company sentiment data...")
+        merged_df = pd.merge(growth_df, company_df, on="company_upper_merge_key", how="left", suffixes=('_growth', '_sentiment'))
+        logger.info(f"Shape after merging with company sentiment: {merged_df.shape}")
+        # Use the company name from growth_df as the primary one, as it's likely more official
+        merged_df['company'] = merged_df['company_growth']
+        merged_df.drop(columns=['company_growth', 'company_sentiment'], errors='ignore', inplace=True)
 
-        # Merge with macro sentiment
-        # Assumed: macro_df has 'theme', 'macro_sentiment_score'
+
+        # Log some results of the first merge for problematic companies
+        example_companies_check = ['ALPHABET INC. (CLASS A)', 'MICROSOFT CORP.', 'AMAZON.COM, INC.', 'ASTRAZENECA PLC', 'ASML HOLDING N.V.'] # Check with official names
+        if not merged_df.empty:
+            logger.debug(f"Post-Merge 1 (Sentiment) check for example companies (matched on 'company_upper_merge_key'):")
+            for ex_co in example_companies_check:
+                ex_data = merged_df[merged_df['company_upper_merge_key'] == ex_co.upper()]
+                if not ex_data.empty:
+                    logger.debug(f"Data for {ex_co.upper()}: Positive={ex_data['positive'].values}, Neutral={ex_data['neutral'].values}, Negative={ex_data['negative'].values}")
+                else:
+                    logger.debug(f"No data found for {ex_co.upper()} after sentiment merge.")
+
+        # Merge 2: merged_df with macro_df (macro sentiment)
         if 'theme' in merged_df.columns and not macro_df.empty:
-             merged_df = pd.merge(merged_df, macro_df[['theme', 'macro_sentiment_score']], on="theme", how="left")
+            logger.info("Merging with macro sentiment data...")
+            logger.debug(f"Unique themes in merged_df (first 5): {merged_df['theme'].unique()[:5]}")
+            logger.debug(f"Unique themes in macro_df (first 5): {macro_df['theme'].unique()[:5]}")
+            merged_df = pd.merge(merged_df, macro_df[['theme', 'macro_sentiment_score']], on="theme", how="left")
+            logger.info(f"Shape after merging with macro sentiment: {merged_df.shape}")
         else:
-            merged_df['macro_sentiment_score'] = pd.NA # Ensure column exists
+            logger.warning("'theme' column not in merged_df or macro_df is empty. Skipping macro sentiment merge.")
+            merged_df['macro_sentiment_score'] = pd.NA
 
-        # Determine overall market sentiment
-        overall_market_sentiment_value = growth_df['market_sentiment'].iloc[0] if 'market_sentiment' in growth_df.columns and not growth_df.empty else 0
-        if overall_market_sentiment_value > 0.1:
-            overall_market_sentiment_string = "Positive"
-        elif overall_market_sentiment_value < -0.1:
-            overall_market_sentiment_string = "Negative"
+        if not merged_df.empty:
+            logger.debug(f"Post-Merge 2 (Macro) check for example companies:")
+            for ex_co in example_companies_check:
+                ex_data = merged_df[merged_df['company_upper_merge_key'] == ex_co.upper()]
+                if not ex_data.empty:
+                    logger.debug(f"Data for {ex_co.upper()}: MacroSectorSentiment={ex_data['macro_sentiment_score'].values}")
+                else:
+                    logger.debug(f"No data for {ex_co.upper()} after macro merge (or it was filtered out).")
+
+
+        overall_market_sentiment_value = growth_df_raw['market_sentiment'].iloc[0] if 'market_sentiment' in growth_df_raw.columns and not growth_df_raw.empty else 0
+        overall_market_sentiment_string = "Positive" if overall_market_sentiment_value > 0.1 else "Negative" if overall_market_sentiment_value < -0.1 else "Neutral"
+
+        if merged_df.empty or 'growth_score' not in merged_df.columns:
+            logger.error("merged_df is empty or 'growth_score' is missing before sorting. Cannot proceed with company selection.")
+            return pd.DataFrame(), overall_market_sentiment_string, queried_companies_normalized
+
+        top_companies_df = merged_df.sort_values(by="growth_score", ascending=False)
+
+        # Prepare final_df (selection of companies)
+        queried_companies_uppercase_keys = [name.upper() for name in queried_companies_normalized]
+        final_df_list = []
+
+        if not queried_companies_uppercase_keys:
+            final_df = top_companies_df.head(top_n).copy() # Use .copy() to avoid SettingWithCopyWarning
+            logger.debug(f"No specific companies queried. Selected top {top_n}. Shape: {final_df.shape}")
         else:
-            overall_market_sentiment_string = "Neutral"
+            logger.debug(f"Processing queried companies: {queried_companies_uppercase_keys}")
+            queried_company_data_list = []
+            for company_key_upper in queried_companies_uppercase_keys:
+                # Match against the merge key
+                company_data = top_companies_df[top_companies_df['company_upper_merge_key'] == company_key_upper]
+                if not company_data.empty:
+                    queried_company_data_list.append(company_data)
+                    logger.debug(f"Found data for queried company key {company_key_upper}. Shape: {company_data.shape}")
+                else:
+                    logger.warning(f"Data for queried company key '{company_key_upper}' not found in top_companies_df.")
 
-        final_df = merged_df.sort_values(by="growth_score", ascending=False).head(top_n)
-        logger.info(f"Successfully prepared LLM context data (LSTM removed). Shape: {final_df.shape}")
+            if queried_company_data_list:
+                queried_companies_selected_df = pd.concat(queried_company_data_list).drop_duplicates(subset=['company_upper_merge_key'])
+                final_df_list.append(queried_companies_selected_df)
+
+            if not final_df_list: # if no queried companies were found in data
+                 final_df = top_companies_df.head(top_n).copy()
+                 logger.debug(f"No queried companies found in data. Selected top {top_n}. Shape: {final_df.shape}")
+            else:
+                companies_to_exclude_keys = final_df_list[0]['company_upper_merge_key'].tolist()
+                num_to_fetch = top_n - len(companies_to_exclude_keys)
+                if num_to_fetch > 0:
+                    remaining_top_df = top_companies_df[~top_companies_df['company_upper_merge_key'].isin(companies_to_exclude_keys)].head(num_to_fetch)
+                    if not remaining_top_df.empty:
+                        final_df_list.append(remaining_top_df)
+                final_df = pd.concat(final_df_list).drop_duplicates(subset=['company_upper_merge_key']).reset_index(drop=True).copy()
+                logger.debug(f"Combined queried and top companies. Shape: {final_df.shape}")
         
-        if 'current_price' not in final_df.columns:
-            logger.warning("'current_price' column is missing from the merged DataFrame.")
-            final_df['current_price'] = pd.NA
+        # --- Integrate yfinance data ---
+        if not final_df.empty:
+            logger.info(f"Enhancing {len(final_df)} companies with live yfinance data...")
+            yfinance_updates = []
+            # Ensure original_company_for_ticker_lookup is present for all rows in final_df
+            # This might require merging it back if it was lost, or ensuring it's selected carefully
+            if 'original_company_for_ticker_lookup' not in final_df.columns:
+                 logger.error("'original_company_for_ticker_lookup' is missing from final_df. Ticker lookup will fail.")
+                 # Attempt to recover it if 'company' (which was company_growth) is the original name
+                 if 'company' in final_df.columns: # This 'company' should be from growth_df
+                     logger.warning("Attempting to use 'company' column from final_df for ticker lookup. Assumed to be original casing.")
+                     final_df['original_company_for_ticker_lookup'] = final_df['company']
+                 else: # Cannot proceed with yfinance if no suitable name for ticker lookup
+                      final_df['original_company_for_ticker_lookup'] = pd.NA
 
-        # Ensure 'predicted_close_price' column (related to LSTM) is NOT present
-        if 'predicted_close_price' in final_df.columns:
+
+            for index, row in final_df.iterrows():
+                # Use the original casing company name for ticker lookup
+                company_name_for_ticker = row.get('original_company_for_ticker_lookup')
+
+                update_values = {'current_price': None, 'sma_20': None, 'sma_50': None, 'previous_close': None, 'day_high': None, 'day_low': None, 'volume': None, 'market_cap': None}
+
+                if pd.isna(company_name_for_ticker):
+                    logger.warning(f"Missing original company name for row index {index}, company_upper_merge_key: {row.get('company_upper_merge_key')}. Cannot fetch yfinance data.")
+                    yfinance_updates.append(update_values)
+                    continue
+
+                logger.debug(f"Attempting ticker lookup for: '{company_name_for_ticker}' (original name)")
+                ticker_symbol = get_ticker_for_company(company_name_for_ticker)
+
+                if ticker_symbol:
+                    logger.debug(f"Fetching yfinance data for {company_name_for_ticker} ({ticker_symbol})")
+                    live_data = get_current_stock_data(ticker_symbol)
+                    if not live_data.get('error'):
+                        update_values['current_price'] = live_data.get('current_price')
+                        update_values['sma_20'] = live_data.get('sma_20')
+                        update_values['sma_50'] = live_data.get('sma_50')
+                        update_values['previous_close'] = live_data.get('previous_close')
+                        update_values['day_high'] = live_data.get('day_high')
+                        update_values['day_low'] = live_data.get('day_low')
+                        update_values['volume'] = live_data.get('volume')
+                        update_values['market_cap'] = live_data.get('market_cap')
+                        logger.debug(f"yfinance data for {ticker_symbol}: Price={update_values['current_price']}, SMA20={update_values['sma_20']}")
+                    else:
+                        logger.warning(f"Could not fetch yfinance data for {company_name_for_ticker} ({ticker_symbol}): {live_data.get('error')}")
+                else:
+                    logger.warning(f"No ticker found for company: '{company_name_for_ticker}'. Cannot fetch yfinance data.")
+                yfinance_updates.append(update_values)
+
+            # Update DataFrame with yfinance data
+            if yfinance_updates: # Check if list is not empty
+                for col_name in ['current_price', 'sma_20', 'sma_50', 'previous_close', 'day_high', 'day_low', 'volume', 'market_cap']:
+                    final_df[col_name] = [d[col_name] for d in yfinance_updates]
+            else:
+                logger.warning("yfinance_updates list is empty. No yfinance data was processed to update final_df.")
+
+        else:
+            logger.info("No companies selected for yfinance data enhancement (final_df is empty).")
+
+        logger.info(f"Successfully prepared LLM context data. Final DF Shape: {final_df.shape if not final_df.empty else '0 rows'}")
+        if not final_df.empty:
+            logger.debug(f"Final DF columns: {final_df.columns.tolist()}")
+            logger.debug(f"Sample of final_df with yfinance data (first 3 rows): \n{final_df.head(3)}")
+
+        if not final_df.empty and 'predicted_close_price' in final_df.columns:
             final_df.drop(columns=['predicted_close_price'], inplace=True, errors='ignore')
 
-        return final_df, overall_market_sentiment_string
+        return final_df, overall_market_sentiment_string, queried_companies_normalized
 
     except FileNotFoundError as e:
-        logger.error(f"Error loading data for LLM context: {e}. Please ensure all prerequisite scripts have run.")
-        return pd.DataFrame(), "Neutral (Data Missing)"
+        logger.error(f"Error loading data for LLM context: {e}. Please ensure all prerequisite scripts have run ({e.filename}).")
+        return pd.DataFrame(), "Neutral (Data Missing)", queried_companies_normalized # return normalized names even if data is missing
     except Exception as e:
         logger.error(f"An unexpected error occurred while preparing LLM context data: {e}", exc_info=True)
-        return pd.DataFrame(), "Neutral (Error)"
+        return pd.DataFrame(), "Neutral (Error)", queried_companies_normalized
 
 
-def generate_dynamic_prompt(user_query, top_companies_df, overall_market_sentiment_string):
+def generate_dynamic_prompt(user_query, top_companies_df, overall_market_sentiment_string, normalized_queried_companies):
     """
     Generates a dynamic prompt for the LLM based on user query, company data, and overall market sentiment.
-    LSTM components have been removed from this version.
     """
     prompt_lines = [
         "You are a stock analyst assistant. Analyze the provided company data in the context of the user's query and the stated overall market sentiment."
     ]
-    prompt_lines.append(f"\nUser Query: \"{user_query}\"\n")
+    prompt_lines.append(f"\nUser Query: \"{user_query}\"")
+    if normalized_queried_companies:
+        prompt_lines.append(f"Normalized Companies from Query: {', '.join(normalized_queried_companies)}")
+    else:
+        prompt_lines.append("No specific companies were clearly identified from the query for focused analysis, but consider the query's general intent.")
+
     prompt_lines.append(f"Overall Market Sentiment: {overall_market_sentiment_string}\n")
     
     instructions = """Your primary role is to answer the user's query by providing a detailed stock and sector analysis for 'tomorrow'. 

--- a/utils/normalization_utils.py
+++ b/utils/normalization_utils.py
@@ -1,0 +1,268 @@
+import pandas as pd
+from thefuzz import process
+import re
+import logging
+import os
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+# Constants
+NASDAQS_COMPANIES_CSV_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "nasdaq_top_companies.csv")
+
+# Global cache for loaded data to avoid reloading CSVs multiple times
+_loaded_data = {
+    "nasdaq_df": None,
+    "name_mapping": None,
+    "ticker_map": None,
+    "common_name_map": None,
+    "clean_official_names": None,
+}
+
+def clean_company_name(name):
+    """
+    Cleans a company name by removing common suffixes, special characters,
+    and converting to lowercase.
+    """
+    if not isinstance(name, str) or not name.strip():
+        return ""
+    # Remove common suffixes, special chars, and extra spaces
+    name = re.sub(r'[^\w\s]', ' ', name.lower()) # Keep spaces
+    name = re.sub(r'\b(inc|llc|ltd|corp|corporation|company|co|plc|holdings|technologies|international|group)\b', '', name, flags=re.IGNORECASE)
+    return ' '.join(name.split()).strip()
+
+def _load_normalization_data():
+    """
+    Loads data from nasdaq_top_companies.csv and prepares mappings.
+    This function is intended for internal use and populates the _loaded_data cache.
+    """
+    if _loaded_data["nasdaq_df"] is not None:
+        logger.debug("Normalization data already loaded. Skipping reload.")
+        return
+
+    try:
+        nasdaq_df = pd.read_csv(NASDAQS_COMPANIES_CSV_PATH)
+        logger.info(f"Loaded NASDAQ companies from {NASDAQS_COMPANIES_CSV_PATH}. Found {len(nasdaq_df)} companies.")
+        _loaded_data["nasdaq_df"] = nasdaq_df
+    except FileNotFoundError:
+        logger.error(f"NASDAQ companies file not found at: {NASDAQS_COMPANIES_CSV_PATH}")
+        # Create empty structures if file not found to prevent downstream errors on first load
+        _loaded_data["nasdaq_df"] = pd.DataFrame(columns=['Company', 'Ticker'])
+        _loaded_data["name_mapping"] = {}
+        _loaded_data["ticker_map"] = {}
+        _loaded_data["common_name_map"] = {}
+        _loaded_data["clean_official_names"] = []
+        return # Exit if the crucial file is missing
+    except Exception as e:
+        logger.error(f"Error loading NASDAQ companies file: {str(e)}")
+        _loaded_data["nasdaq_df"] = pd.DataFrame(columns=['Company', 'Ticker']) # Fallback
+        _loaded_data["name_mapping"] = {}
+        _loaded_data["ticker_map"] = {}
+        _loaded_data["common_name_map"] = {}
+        _loaded_data["clean_official_names"] = []
+        return
+
+    # Create cleaned versions for matching
+    nasdaq_df['clean_name'] = nasdaq_df['Company'].fillna('').apply(clean_company_name)
+    _loaded_data["name_mapping"] = dict(zip(nasdaq_df['clean_name'], nasdaq_df['Company']))
+    _loaded_data["clean_official_names"] = list(_loaded_data["name_mapping"].keys())
+
+    # Create ticker_map
+    ticker_map = {}
+    for _, row in nasdaq_df.iterrows():
+        ticker = row['Ticker']
+        company_name = row['Company']
+        if pd.notna(ticker) and pd.notna(company_name):
+            ticker_map[ticker.upper()] = company_name
+    _loaded_data["ticker_map"] = ticker_map
+    logger.info(f"Created ticker_map with {len(ticker_map)} entries.")
+
+    # Create common_name_map
+    # Ensure these map to the *exact* names from nasdaq_top_companies.csv
+    common_name_map = {
+        "google": "Alphabet Inc. (Class A)",
+        "alphabet": "Alphabet Inc. (Class A)",
+        "apple": "Apple Inc.",
+        "microsoft": "Microsoft", # Assuming 'Microsoft' is the exact name in nasdaq_top_companies.csv
+        "amazon": "Amazon",       # Assuming 'Amazon' is the exact name
+        "nvidia": "Nvidia",
+        "meta": "Meta Platforms",
+        "tesla": "Tesla, Inc."
+        # Add more as needed
+    }
+
+    # Validate and correct common_name_map values
+    # This ensures that the mapped official names are actually present in nasdaq_top_companies
+    corrected_common_name_map = {}
+    for common, official_guess in common_name_map.items():
+        # Check if the guessed official name is directly in the list of official company names
+        if official_guess in _loaded_data["name_mapping"].values():
+            corrected_common_name_map[common] = official_guess
+        else:
+            # If not, try to find it by its cleaned version
+            cleaned_official_guess = clean_company_name(official_guess)
+            if cleaned_official_guess in _loaded_data["name_mapping"]:
+                corrected_common_name_map[common] = _loaded_data["name_mapping"][cleaned_official_guess]
+                logger.info(f"Common name '{common}' mapped to '{official_guess}' which was corrected to '{corrected_common_name_map[common]}' via clean name matching.")
+            else:
+                # Fallback: try fuzzy matching the GUESS against CLEANED official names
+                match, score = process.extractOne(cleaned_official_guess, _loaded_data["clean_official_names"])
+                if score >= 90: # High threshold for auto-correction
+                    corrected_official_name = _loaded_data["name_mapping"][match]
+                    corrected_common_name_map[common] = corrected_official_name
+                    logger.warning(f"Common name '{common}' mapped to '{official_guess}', "
+                                   f"fuzzy matched and corrected to '{corrected_official_name}' (score: {score}).")
+                else:
+                    logger.error(f"Could not confidently map common name '{common}' (guessed '{official_guess}') to an official NASDAQ name. "
+                                 f"Best fuzzy match '{match}' (score: {score}) was below threshold 90. This mapping will be skipped.")
+
+    _loaded_data["common_name_map"] = corrected_common_name_map
+    logger.info(f"Created common_name_map with {len(_loaded_data['common_name_map'])} entries after validation.")
+
+
+def normalize_company_name(name_to_normalize):
+    """
+    Normalizes a given company name or ticker to its official company name
+    using various matching strategies.
+    """
+    _load_normalization_data() # Ensure data is loaded
+
+    if not isinstance(name_to_normalize, str) or not name_to_normalize.strip():
+        return ""
+
+    # 1. Direct Ticker Match (if name_to_normalize is a potential ticker)
+    # Check if the input itself is a ticker (common for user queries)
+    potential_ticker_input = name_to_normalize.upper()
+    if potential_ticker_input in _loaded_data["ticker_map"]:
+        official_name = _loaded_data["ticker_map"][potential_ticker_input]
+        logger.debug(f"Normalized '{name_to_normalize}' to '{official_name}' via direct ticker input map.")
+        return official_name
+
+    # Also check for tickers within a longer string (original logic)
+    potential_tickers_in_string = re.findall(r'\b([A-Z]{1,5})\b', name_to_normalize)
+    for ticker in potential_tickers_in_string:
+        if ticker in _loaded_data["ticker_map"]:
+            official_name = _loaded_data["ticker_map"][ticker]
+            logger.debug(f"Normalized '{name_to_normalize}' to '{official_name}' via ticker '{ticker}' found in string.")
+            return official_name
+
+    cleaned_name_lower = clean_company_name(name_to_normalize)
+    if not cleaned_name_lower:
+        logger.debug(f"Could not normalize '{name_to_normalize}' after cleaning, result is empty.")
+        return ""
+
+    # 2. Common Name Match
+    if cleaned_name_lower in _loaded_data["common_name_map"]:
+        official_name = _loaded_data["common_name_map"][cleaned_name_lower]
+        logger.debug(f"Normalized '{name_to_normalize}' (cleaned: '{cleaned_name_lower}') to '{official_name}' via common name map.")
+        return official_name
+
+    # 3. Exact Cleaned Match
+    if cleaned_name_lower in _loaded_data["name_mapping"]:
+        official_name = _loaded_data["name_mapping"][cleaned_name_lower]
+        logger.debug(f"Normalized '{name_to_normalize}' (cleaned: '{cleaned_name_lower}') to '{official_name}' via exact cleaned match.")
+        return official_name
+
+    # 4. Fuzzy Match
+    try:
+        if not _loaded_data["clean_official_names"]:
+            logger.warning("Clean official names list is empty, skipping fuzzy match.")
+            return ""
+
+        match_result = process.extractOne(cleaned_name_lower, _loaded_data["clean_official_names"])
+        if match_result:
+            match, score = match_result
+            if score >= 75: # Adjusted threshold, can be tuned
+                official_name = _loaded_data["name_mapping"][match]
+                logger.debug(f"Normalized '{name_to_normalize}' (cleaned: '{cleaned_name_lower}') to '{official_name}' via fuzzy match (score: {score}).")
+                return official_name
+            else:
+                logger.debug(f"Fuzzy match score for '{name_to_normalize}' (cleaned: '{cleaned_name_lower}') was {score}, below threshold 75.")
+        else:
+            logger.debug(f"No fuzzy match found for '{name_to_normalize}' (cleaned: '{cleaned_name_lower}').")
+
+    except Exception as e:
+        logger.warning(f"Error during fuzzy matching for '{name_to_normalize}' (cleaned: '{cleaned_name_lower}'): {str(e)}")
+
+    logger.info(f"No normalization match found for: '{name_to_normalize}' (cleaned: '{cleaned_name_lower}'). Returning original as a last resort if it's a proper noun, else empty.")
+    # Fallback: if it looks like a proper name (e.g., starts with capital or is all caps) return it, else empty
+    if name_to_normalize.isupper() or (name_to_normalize[0].isupper() if name_to_normalize else False):
+        # Check if the original name_to_normalize is an official name already
+        if name_to_normalize in _loaded_data["name_mapping"].values():
+             return name_to_normalize
+
+    # If user query was "google stco ktowmorrow", this function would be called with "google stco ktowmorrow".
+    # It would fail to find a direct match.
+    # A more advanced query parser in stock_predictor.py might split this into "google", "stco", "ktowmorrow"
+    # and call normalize_company_name on each part. "google" would then be normalized.
+    logger.info(f"Final fallback: No normalization found for '{name_to_normalize}'. Returning empty string.")
+    return ""
+
+
+def get_ticker_for_company(official_company_name):
+    """
+    Returns the ticker for a given official company name.
+    """
+    _load_normalization_data()
+    for ticker, company_name in _loaded_data["ticker_map"].items():
+        if company_name == official_company_name:
+            return ticker
+    return None
+
+def get_company_for_ticker(ticker_symbol):
+    """
+    Returns the official company name for a given ticker symbol.
+    """
+    _load_normalization_data()
+    return _loaded_data["ticker_map"].get(ticker_symbol.upper())
+
+
+if __name__ == '__main__':
+    # Basic test cases
+    logging.basicConfig(level=logging.DEBUG) # Enable debug for testing this module
+    _load_normalization_data() # Explicitly load for testing
+
+    test_names = [
+        "Google", "google", "Alphabet Inc. (Class A)", "GOOGL", "GOOG",
+        "Apple", "AAPL", "Apple Inc.",
+        "Microsoft Corp", "MSFT",
+        "Amazon.com Inc.", "AMZN",
+        "NVIDIA Corporation", "NVDA",
+        "Tesla", "TSLA",
+        "NonExistentCompany", "XYZTICKER",
+        "Adobe", "ADBE",
+        "Netflix inc", "NFLX",
+        "Meta Platforms",
+        "google stco ktowmorrow" # Test the problematic query
+    ]
+    for name in test_names:
+        normalized = normalize_company_name(name)
+        ticker = get_ticker_for_company(normalized) if normalized else "N/A"
+        print(f"Original: '{name}' -> Normalized: '{normalized}' (Ticker: {ticker})")
+
+    print("\nTesting direct ticker lookup:")
+    print(f"Ticker 'AAPL': Company is '{get_company_for_ticker('AAPL')}'")
+    print(f"Ticker 'GOOGL': Company is '{get_company_for_ticker('GOOGL')}'")
+    print(f"Ticker 'XYZ': Company is '{get_company_for_ticker('XYZ')}'")
+
+    print("\nTesting common name map directly (for debugging):")
+    if _loaded_data["common_name_map"]:
+        for common, official in _loaded_data["common_name_map"].items():
+            print(f"Common: '{common}' -> Official in map: '{official}'")
+    else:
+        print("Common name map is empty or not loaded.")
+
+    print(f"\nIs 'Microsoft' an official name in mapping? {'Microsoft' in _loaded_data['name_mapping'].values()}")
+    print(f"Is 'Amazon' an official name in mapping? {'Amazon' in _loaded_data['name_mapping'].values()}")
+
+    # Test the problematic query again after ensuring data is loaded
+    problem_query = "google stco ktowmorrow"
+    # The current normalize_company_name expects a single company name.
+    # A query parser would be needed to split this.
+    # For now, let's test its components:
+    print(f"\nTesting components of problematic query:")
+    print(f"Original: 'google' -> Normalized: '{normalize_company_name('google')}'")
+    print(f"Original: 'stco' -> Normalized: '{normalize_company_name('stco')}'") # Likely no match
+    print(f"Original: 'ktowmorrow' -> Normalized: '{normalize_company_name('ktowmorrow')}'") # Likely no match
+
+```

--- a/utils/yfinance_utils.py
+++ b/utils/yfinance_utils.py
@@ -1,0 +1,96 @@
+import yfinance as yf
+import pandas as pd
+import logging
+
+logger = logging.getLogger(__name__)
+
+def get_current_stock_data(ticker_symbol: str) -> dict:
+    """
+    Fetches current stock data including price, previous close, day's range,
+    and calculates 20-day and 50-day Simple Moving Averages (SMAs).
+
+    Args:
+        ticker_symbol (str): The stock ticker symbol.
+
+    Returns:
+        dict: A dictionary containing current stock data and SMAs.
+              Returns an empty dict if data fetching fails.
+    """
+    data = {}
+    try:
+        ticker = yf.Ticker(ticker_symbol)
+
+        # Fetch current market price using 'info'
+        info = ticker.info
+        data['current_price'] = info.get('currentPrice', info.get('regularMarketPrice'))
+        if data['current_price'] is None: # Fallback for some tickers or market states
+            data['current_price'] = info.get('previousClose')
+            logger.warning(f"Using previousClose as currentPrice for {ticker_symbol} as currentPrice/regularMarketPrice is None.")
+
+        data['previous_close'] = info.get('previousClose')
+        data['day_high'] = info.get('dayHigh')
+        data['day_low'] = info.get('dayLow')
+        data['volume'] = info.get('volume')
+        data['market_cap'] = info.get('marketCap')
+        data['company_name'] = info.get('shortName', info.get('longName')) # For display
+
+        # Fetch historical data for SMA calculation (approx 3 months for 50-day SMA)
+        hist = ticker.history(period="3mo")
+        if not hist.empty:
+            # Calculate SMAs
+            data['sma_20'] = hist['Close'].rolling(window=20).mean().iloc[-1] if len(hist) >= 20 else None
+            data['sma_50'] = hist['Close'].rolling(window=50).mean().iloc[-1] if len(hist) >= 50 else None
+        else:
+            data['sma_20'] = None
+            data['sma_50'] = None
+            logger.warning(f"Could not fetch enough historical data for SMA calculation for {ticker_symbol}.")
+
+        # Log the fetched data for debugging
+        logger.debug(f"Fetched yfinance data for {ticker_symbol}: {data}")
+
+    except Exception as e:
+        logger.error(f"Error fetching data for {ticker_symbol} using yfinance: {e}", exc_info=False) # Set exc_info to False for cleaner logs unless debugging yfinance
+        # Return empty dict or specific error structure if preferred
+        return {
+            'current_price': None, 'previous_close': None, 'day_high': None, 'day_low': None,
+            'volume': None, 'market_cap': None, 'company_name': None, 'sma_20': None, 'sma_50': None, 'error': str(e)
+        }
+
+    # Filter out None values before returning for cleaner output, but keep error if present
+    # cleaned_data = {k: v for k, v in data.items() if v is not None or k == 'error'}
+    # return cleaned_data
+    return data
+
+
+if __name__ == '__main__':
+    # Test cases
+    logging.basicConfig(level=logging.DEBUG)
+    test_tickers = ["AAPL", "GOOGL", "MSFT", "NONEXISTENTTICKERXYZ"]
+    for t in test_tickers:
+        print(f"\n--- Fetching data for {t} ---")
+        stock_info = get_current_stock_data(t)
+        if stock_info.get('error'):
+            print(f"Error for {t}: {stock_info['error']}")
+        else:
+            for key, value in stock_info.items():
+                if isinstance(value, (int, float)) and value is not None:
+                    print(f"  {key}: {value:.2f}" if pd.notna(value) and key not in ['volume', 'market_cap'] else f"  {key}: {value}")
+                else:
+                    print(f"  {key}: {value}")
+        print("--- End ---")
+
+    # Example: How it might be used with normalization utils
+    # from normalization_utils import normalize_company_name, get_ticker_for_company, _load_normalization_data
+    # _load_normalization_data() # Load NASDAQ data etc.
+    # company_query = "Google"
+    # official_name = normalize_company_name(company_query)
+    # if official_name:
+    #     ticker_sym = get_ticker_for_company(official_name)
+    #     if ticker_sym:
+    #         print(f"\n--- Fetching data for '{company_query}' (Normalized: '{official_name}', Ticker: {ticker_sym}) ---")
+    #         goog_data = get_current_stock_data(ticker_sym)
+    #         print(goog_data)
+    #     else:
+    #         print(f"Could not find ticker for {official_name}")
+    # else:
+    #     print(f"Could not normalize company: {company_query}")


### PR DESCRIPTION
…mmary

1. Fix `market_sentiment.py`:
   - Changed yfinance data access from 'Adj Close' to 'Close' for VIX and S&P 500, as 'Close' is more reliable for indices.
   - Added checks for column existence and empty data after download to prevent KeyErrors.

2. Modify `generate_company_sentiment.py`:
   - Integrated `utils.normalization_utils.normalize_company_name`.
   - The script now normalizes company names from its input file (`merged_sentiment_output_with_companies_and_sentiment.csv`) before aggregating sentiment counts.
   - This ensures the output `data/company_sentiment_normalized.csv` contains standardized official company names, crucial for downstream merges in `stock_predictor.py`.
   - Added logging and error handling.