### PR TITLE
Fix: Handle three return values from prepare_llm_context_data

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -212,7 +212,8 @@ with st.sidebar:
             try:
                 # 1. Get the latest company context data
                 logger.info("Streamlit App: Calling prepare_llm_context_data()")
-                top_companies_df, market_sentiment_str = prepare_llm_context_data(user_query=prompt) # Pass user query
+                # Correctly unpack the three values returned by prepare_llm_context_data
+                top_companies_df, market_sentiment_str, queried_companies_normalized = prepare_llm_context_data(user_query=prompt)
 
                 if top_companies_df.empty:
                     logger.warning("Streamlit App: No company context data returned from prepare_llm_context_data().")
@@ -220,7 +221,8 @@ with st.sidebar:
 
                 # 2. Generate the dynamic prompt
                 logger.info(f"Streamlit App: Generating dynamic prompt for user query: {prompt}")
-                dynamic_prompt_text = generate_dynamic_prompt(prompt, top_companies_df, market_sentiment_str) # Pass market_sentiment_str
+                # Pass all necessary arguments, including the new queried_companies_normalized
+                dynamic_prompt_text = generate_dynamic_prompt(prompt, top_companies_df, market_sentiment_str, queried_companies_normalized)
                 logger.debug(f"Streamlit App: Generated prompt: {dynamic_prompt_text}")
 
                 # 3. Get response from OpenAI


### PR DESCRIPTION
Updated streamlit_app.py to correctly unpack all three values returned by the prepare_llm_context_data function. The third value, queried_companies_normalized, is now also passed to the generate_dynamic_prompt function, aligning the call with its definition.