### PR TITLE
fix: Correct data loading and company name normalization

### DIFF
--- a/app/llm_integration/stock_predictor.py
+++ b/app/llm_integration/stock_predictor.py
@@ -100,7 +100,7 @@ def prepare_llm_context_data(user_query, top_n=25):
 
     logger.info(f"Normalized companies from query '{user_query}': {queried_companies_normalized}")
 
-    data_dir = os.path.join(parent_dir, "data")
+    data_dir = os.path.join(os.path.dirname(parent_dir), "data")
     company_sentiment_path = os.path.join(data_dir, "company_sentiment_normalized.csv")
     predict_growth_path = os.path.join(data_dir, "predict_growth.csv")
     macro_sentiment_path = os.path.join(data_dir, "macro_sentiment.csv")

--- a/scripts/merge_sources.py
+++ b/scripts/merge_sources.py
@@ -59,7 +59,7 @@ reddit_df = reddit_df.rename(columns={
 reddit_df["source"] = "reddit"
 
 # Standardize column order
-columns = ["timestamp", "headline", "text", "source", "url"]
+columns = ["timestamp", "headline", "text", "source", "url", "company"]
 news_df = news_df[columns]
 reddit_df = reddit_df[columns]
 

--- a/utils/normalization_utils.py
+++ b/utils/normalization_utils.py
@@ -172,12 +172,12 @@ def normalize_company_name(name_to_normalize):
         match_result = process.extractOne(cleaned_name_lower, _loaded_data["clean_official_names"])
         if match_result:
             match, score = match_result
-            if score >= 75: # Adjusted threshold, can be tuned
+            if score >= 90: # Adjusted threshold, can be tuned
                 official_name = _loaded_data["name_mapping"][match]
                 logger.debug(f"Normalized '{name_to_normalize}' (cleaned: '{cleaned_name_lower}') to '{official_name}' via fuzzy match (score: {score}).")
                 return official_name
             else:
-                logger.debug(f"Fuzzy match score for '{name_to_normalize}' (cleaned: '{cleaned_name_lower}') was {score}, below threshold 75.")
+                logger.debug(f"Fuzzy match score for '{name_to_normalize}' (cleaned: '{cleaned_name_lower}') was {score}, below threshold 90.")
         else:
             logger.debug(f"No fuzzy match found for '{name_to_normalize}' (cleaned: '{cleaned_name_lower}').")
 


### PR DESCRIPTION
- Fix file path for loading data in stock_predictor.py.
- Include company column in merged_sentiment_input.csv.
- Make fuzzy matching for company names more strict.